### PR TITLE
DX-1034 Fix documentation - ApiClient.default is undefined in referenced code snip

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Please follow the [installation](#installation) instruction and execute the foll
 ```javascript
 var ArtikCloud = require('artikcloud-js');
 
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];

--- a/docs/DeviceTypesApi.md
+++ b/docs/DeviceTypesApi.md
@@ -22,7 +22,7 @@ Get a Device Type&#39;s available manifest versions
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];
@@ -73,7 +73,7 @@ Retrieves a Device Type
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];
@@ -124,7 +124,7 @@ Retrieves Device Types
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];
@@ -183,7 +183,7 @@ Get a Device Type&#39;s manifest properties for the latest version.
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];
@@ -234,7 +234,7 @@ Get a Device Type&#39;s manifest properties for a specific version.
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];

--- a/docs/DevicesApi.md
+++ b/docs/DevicesApi.md
@@ -25,7 +25,7 @@ Create a device
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];
@@ -76,7 +76,7 @@ Deletes a device
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];
@@ -127,7 +127,7 @@ Deletes a device&#39;s token
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];
@@ -178,7 +178,7 @@ Retrieves a device
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];
@@ -229,7 +229,7 @@ Return the presence status of the given device along with the time it was last s
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];
@@ -280,7 +280,7 @@ Retrieves a device&#39;s token
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];
@@ -331,7 +331,7 @@ Updates a device
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];
@@ -385,7 +385,7 @@ Updates a device&#39;s token
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];

--- a/docs/DevicesManagementApi.md
+++ b/docs/DevicesManagementApi.md
@@ -32,7 +32,7 @@ Create a new task for one or more devices
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];
@@ -83,7 +83,7 @@ Deletes a device&#39;s properties.
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];
@@ -134,7 +134,7 @@ Returns the list of tasks for a particular device id with optional status filter
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];
@@ -197,7 +197,7 @@ Read a device type device management information.
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];
@@ -248,7 +248,7 @@ Get a device type&#39;s device management manifest properties
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];
@@ -299,7 +299,7 @@ Read a device&#39;s properties.
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];
@@ -354,7 +354,7 @@ Returns the details and status of a task id and the individual statuses of each 
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];
@@ -415,7 +415,7 @@ Returns the history of the status changes for a specific task id, or for a speci
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];
@@ -470,7 +470,7 @@ Returns the details and global status of a specific task id.
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];
@@ -521,7 +521,7 @@ Returns the all the tasks for a device type.
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];
@@ -584,7 +584,7 @@ Query device properties across devices.
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];
@@ -645,7 +645,7 @@ Updates a device type information
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];
@@ -699,7 +699,7 @@ Updates a device&#39;s server properties.
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];
@@ -753,7 +753,7 @@ Updates a task for all devices - For now just allows changing the state to cance
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];
@@ -807,7 +807,7 @@ Updates a task for a specific device - For now just allows changing the state to
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];

--- a/docs/ExportApi.md
+++ b/docs/ExportApi.md
@@ -21,7 +21,7 @@ Export normalized messages. The following input combinations are supported:&lt;b
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];
@@ -72,7 +72,7 @@ Get the history of export requests.
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];
@@ -128,7 +128,7 @@ Retrieve result of the export query in tgz format. The tar file may contain one 
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];
@@ -179,7 +179,7 @@ Check status of the export query.
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];

--- a/docs/MessagesApi.md
+++ b/docs/MessagesApi.md
@@ -26,7 +26,7 @@ Get Histogram on normalized messages.
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];
@@ -88,7 +88,7 @@ Get normalized message presence.
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];
@@ -151,7 +151,7 @@ Get last messages normalized.
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];
@@ -207,7 +207,7 @@ Get Aggregates on normalized messages.
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];
@@ -267,7 +267,7 @@ Get message snapshots.
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];
@@ -322,7 +322,7 @@ Get the actions normalized
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];
@@ -388,7 +388,7 @@ Get the messages normalized
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];
@@ -458,7 +458,7 @@ Send Actions
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];
@@ -509,7 +509,7 @@ Send a message
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];

--- a/docs/RegistrationsApi.md
+++ b/docs/RegistrationsApi.md
@@ -20,7 +20,7 @@ This call updates the registration request issued earlier by associating it with
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];
@@ -71,7 +71,7 @@ This call checks the status of the request so users can poll and know when regis
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];
@@ -122,7 +122,7 @@ This call clears any associations from the secure device registration.
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];

--- a/docs/RulesApi.md
+++ b/docs/RulesApi.md
@@ -21,7 +21,7 @@ Create a new Rule
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];
@@ -75,7 +75,7 @@ Delete a Rule
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];
@@ -126,7 +126,7 @@ Get a rule using the Rule ID
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];
@@ -177,7 +177,7 @@ Update an existing Rule
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];

--- a/docs/TagsApi.md
+++ b/docs/TagsApi.md
@@ -20,7 +20,7 @@ Get all tags marked as categories
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];
@@ -65,7 +65,7 @@ Get tag suggestions for applications, device types that have been most used with
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];
@@ -123,7 +123,7 @@ Get all tags related to the list of categories
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];

--- a/docs/TokensApi.md
+++ b/docs/TokensApi.md
@@ -20,7 +20,7 @@ Check Token
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];
@@ -71,7 +71,7 @@ Refresh Token
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];
@@ -125,7 +125,7 @@ Returns the Token Information
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];

--- a/docs/UsersApi.md
+++ b/docs/UsersApi.md
@@ -25,7 +25,7 @@ Create application properties for a user
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];
@@ -83,7 +83,7 @@ Deletes a user&#39;s application properties
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];
@@ -138,7 +138,7 @@ Get&#39;s the current user&#39;s profile
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];
@@ -183,7 +183,7 @@ Retrieve User&#39;s Device Types
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];
@@ -242,7 +242,7 @@ Retrieve User&#39;s Devices
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];
@@ -301,7 +301,7 @@ Get application properties of a user
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];
@@ -356,7 +356,7 @@ Retrieve User&#39;s Rules
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];
@@ -415,7 +415,7 @@ Updates application properties of a user
 ### Example
 ```javascript
 var ArtikCloud = require('artikcloud-js');
-var defaultClient = ArtikCloud.ApiClient.default;
+var defaultClient = ArtikCloud.ApiClient.instance;
 
 // Configure OAuth2 access token for authorization: artikcloud_oauth
 var artikcloud_oauth = defaultClient.authentications['artikcloud_oauth'];


### PR DESCRIPTION
DX-1034 Fix documentation - ApiClient.default is undefined in referenced code snip

Resolves #4 - This fixes the following 63 code snips in documentation referencing the wrong
API Client path.

Incorrect: ArtikCloud.ApiClient.default
Correct: ArtikCloud.ApiClient.instance

README.md:52:var instanceClient = ArtikCloud.ApiClient.instance;
docs/DevicesApi.md:28:var instanceClient = ArtikCloud.ApiClient.instance;
docs/DevicesApi.md:79:var instanceClient = ArtikCloud.ApiClient.instance;
docs/DevicesApi.md:130:var instanceClient = ArtikCloud.ApiClient.instance;
docs/DevicesApi.md:181:var instanceClient = ArtikCloud.ApiClient.instance;
docs/DevicesApi.md:232:var instanceClient = ArtikCloud.ApiClient.instance;
docs/DevicesApi.md:283:var instanceClient = ArtikCloud.ApiClient.instance;
docs/DevicesApi.md:334:var instanceClient = ArtikCloud.ApiClient.instance;
docs/DevicesApi.md:388:var instanceClient = ArtikCloud.ApiClient.instance;
docs/DevicesManagementApi.md:35:var instanceClient = ArtikCloud.ApiClient.instance;
docs/DevicesManagementApi.md:86:var instanceClient = ArtikCloud.ApiClient.instance;
docs/DevicesManagementApi.md:137:var instanceClient = ArtikCloud.ApiClient.instance;
docs/DevicesManagementApi.md:200:var instanceClient = ArtikCloud.ApiClient.instance;
docs/DevicesManagementApi.md:251:var instanceClient = ArtikCloud.ApiClient.instance;
docs/DevicesManagementApi.md:302:var instanceClient = ArtikCloud.ApiClient.instance;
docs/DevicesManagementApi.md:357:var instanceClient = ArtikCloud.ApiClient.instance;
docs/DevicesManagementApi.md:418:var instanceClient = ArtikCloud.ApiClient.instance;
docs/DevicesManagementApi.md:473:var instanceClient = ArtikCloud.ApiClient.instance;
docs/DevicesManagementApi.md:524:var instanceClient = ArtikCloud.ApiClient.instance;
docs/DevicesManagementApi.md:587:var instanceClient = ArtikCloud.ApiClient.instance;
docs/DevicesManagementApi.md:648:var instanceClient = ArtikCloud.ApiClient.instance;
docs/DevicesManagementApi.md:702:var instanceClient = ArtikCloud.ApiClient.instance;
docs/DevicesManagementApi.md:756:var instanceClient = ArtikCloud.ApiClient.instance;
docs/DevicesManagementApi.md:810:var instanceClient = ArtikCloud.ApiClient.instance;
docs/DeviceTypesApi.md:25:var instanceClient = ArtikCloud.ApiClient.instance;
docs/DeviceTypesApi.md:76:var instanceClient = ArtikCloud.ApiClient.instance;
docs/DeviceTypesApi.md:127:var instanceClient = ArtikCloud.ApiClient.instance;
docs/DeviceTypesApi.md:186:var instanceClient = ArtikCloud.ApiClient.instance;
docs/DeviceTypesApi.md:237:var instanceClient = ArtikCloud.ApiClient.instance;
docs/ExportApi.md:24:var instanceClient = ArtikCloud.ApiClient.instance;
docs/ExportApi.md:75:var instanceClient = ArtikCloud.ApiClient.instance;
docs/ExportApi.md:131:var instanceClient = ArtikCloud.ApiClient.instance;
docs/ExportApi.md:182:var instanceClient = ArtikCloud.ApiClient.instance;
docs/MessagesApi.md:29:var instanceClient = ArtikCloud.ApiClient.instance;
docs/MessagesApi.md:91:var instanceClient = ArtikCloud.ApiClient.instance;
docs/MessagesApi.md:154:var instanceClient = ArtikCloud.ApiClient.instance;
docs/MessagesApi.md:210:var instanceClient = ArtikCloud.ApiClient.instance;
docs/MessagesApi.md:270:var instanceClient = ArtikCloud.ApiClient.instance;
docs/MessagesApi.md:325:var instanceClient = ArtikCloud.ApiClient.instance;
docs/MessagesApi.md:391:var instanceClient = ArtikCloud.ApiClient.instance;
docs/MessagesApi.md:461:var instanceClient = ArtikCloud.ApiClient.instance;
docs/MessagesApi.md:512:var instanceClient = ArtikCloud.ApiClient.instance;
docs/RegistrationsApi.md:23:var instanceClient = ArtikCloud.ApiClient.instance;
docs/RegistrationsApi.md:74:var instanceClient = ArtikCloud.ApiClient.instance;
docs/RegistrationsApi.md:125:var instanceClient = ArtikCloud.ApiClient.instance;
docs/RulesApi.md:24:var instanceClient = ArtikCloud.ApiClient.instance;
docs/RulesApi.md:78:var instanceClient = ArtikCloud.ApiClient.instance;
docs/RulesApi.md:129:var instanceClient = ArtikCloud.ApiClient.instance;
docs/RulesApi.md:180:var instanceClient = ArtikCloud.ApiClient.instance;
docs/TagsApi.md:23:var instanceClient = ArtikCloud.ApiClient.instance;
docs/TagsApi.md:68:var instanceClient = ArtikCloud.ApiClient.instance;
docs/TagsApi.md:126:var instanceClient = ArtikCloud.ApiClient.instance;
docs/TokensApi.md:23:var instanceClient = ArtikCloud.ApiClient.instance;
docs/TokensApi.md:74:var instanceClient = ArtikCloud.ApiClient.instance;
docs/TokensApi.md:128:var instanceClient = ArtikCloud.ApiClient.instance;
docs/UsersApi.md:28:var instanceClient = ArtikCloud.ApiClient.instance;
docs/UsersApi.md:86:var instanceClient = ArtikCloud.ApiClient.instance;
docs/UsersApi.md:141:var instanceClient = ArtikCloud.ApiClient.instance;
docs/UsersApi.md:186:var instanceClient = ArtikCloud.ApiClient.instance;
docs/UsersApi.md:245:var instanceClient = ArtikCloud.ApiClient.instance;
docs/UsersApi.md:304:var instanceClient = ArtikCloud.ApiClient.instance;
docs/UsersApi.md:359:var instanceClient = ArtikCloud.ApiClient.instance;
docs/UsersApi.md:418:var instanceClient = ArtikCloud.ApiClient.instance;